### PR TITLE
Add human tracking with toggle

### DIFF
--- a/apps/scs/lib/otonom.dart
+++ b/apps/scs/lib/otonom.dart
@@ -16,6 +16,7 @@ class _OtonomPageState extends State<OtonomPage> {
   Uint8List? _mapBytes;
   bool _mapError = false;
   Timer? _mapTimer;
+  bool _trackingEnabled = false;
 
   @override
   void initState() {
@@ -71,6 +72,19 @@ class _OtonomPageState extends State<OtonomPage> {
     }
   }
 
+  Future<void> _setTracking(bool enable) async {
+    final mode = enable ? 'on' : 'off';
+    try {
+      await http
+          .post(Uri.parse('http://192.168.1.130:8000/person_tracking'),
+              body: mode)
+          .timeout(const Duration(seconds: 2));
+    } catch (e) {
+      // ignore: avoid_print
+      print('Tracking toggle failed: $e');
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -94,6 +108,14 @@ class _OtonomPageState extends State<OtonomPage> {
           ElevatedButton(
             onPressed: _fetchMap,
             child: const Text('Haritayı Güncelle'),
+          ),
+          SwitchListTile(
+            title: const Text('İnsan Takibi'),
+            value: _trackingEnabled,
+            onChanged: (val) {
+              setState(() => _trackingEnabled = val);
+              _setTracking(val);
+            },
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- add person tracking to OAK mapping node that turns robot toward detected humans
- add switch on autonomous page to enable/disable tracking via HTTP

## Testing
- `flutter test` *(fails: command not found)*
- `python -m py_compile apps/robot/src/oak_streamer/oak_streamer/oak_mapping_node.py`
- `pytest` *(fails: ModuleNotFoundError: serial, ament_*)


------
https://chatgpt.com/codex/tasks/task_e_68c02c88b0c88323bc5a5bafc4755e7b