### PR TITLE
Fix Socket.listen callback types in CameraService

### DIFF
--- a/apps/scs/lib/camera_service.dart
+++ b/apps/scs/lib/camera_service.dart
@@ -48,8 +48,8 @@ class CameraService extends ChangeNotifier {
       _socket = await Socket.connect(_cameraIp, _cameraPort);
       _connected = true;
       _socket!.listen(_onData,
-          onDone: (_) => _handleDisconnect(),
-          onError: (_) => _handleDisconnect());
+          onDone: _handleDisconnect,
+          onError: (error) => _handleDisconnect());
       notifyListeners();
     } catch (e) {
       _connected = false;


### PR DESCRIPTION
## Summary
- fix Socket.listen callbacks in CameraService to match expected signatures

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0404951288323bed6fdc58649fcc0