### PR TITLE
Fix camera feed by allowing network access on Android

### DIFF
--- a/apps/scs/android/app/src/main/AndroidManifest.xml
+++ b/apps/scs/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:label="scs_app"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"


### PR DESCRIPTION
## Summary
- allow cleartext network traffic and internet permission in Android manifest so camera stream can connect

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68c041b767388323b6d723278fc233c3